### PR TITLE
Add testing for Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: Checkout source

--- a/continous_integeration/environment-3.10.yaml
+++ b/continous_integeration/environment-3.10.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.10
-  - dask[dataframe,distributed]
+  - dask
   - pyarrow
   - pytest
   - pytest-cov

--- a/continous_integeration/environment-3.10.yaml
+++ b/continous_integeration/environment-3.10.yaml
@@ -1,0 +1,10 @@
+name: test-environment
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - dask[dataframe,distributed]
+  - pyarrow
+  - pytest
+  - pytest-cov
+  - mock

--- a/continous_integeration/environment-3.11.yaml
+++ b/continous_integeration/environment-3.11.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.11
-  - dask[dataframe,distributed]
+  - dask
   - pyarrow
   - pytest
   - pytest-cov

--- a/continous_integeration/environment-3.11.yaml
+++ b/continous_integeration/environment-3.11.yaml
@@ -1,0 +1,10 @@
+name: test-environment
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - dask[dataframe,distributed]
+  - pyarrow
+  - pytest
+  - pytest-cov
+  - mock

--- a/continous_integeration/environment-3.7.yaml
+++ b/continous_integeration/environment-3.7.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - dask[dataframe,distributed]
+  - dask
   - pyarrow
   - pytest
   - pytest-cov

--- a/continous_integeration/environment-3.8.yaml
+++ b/continous_integeration/environment-3.8.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
-  - dask[dataframe,distributed]
+  - dask
   - pyarrow
   - pytest
   - pytest-cov

--- a/continous_integeration/environment-3.9.yaml
+++ b/continous_integeration/environment-3.9.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
-  - dask[dataframe,distributed]
+  - dask
   - pyarrow
   - pytest
   - pytest-cov


### PR DESCRIPTION
Today Dask support Python 3.9, 3.10, and 3.11. This PR adds testing matrix entries for Python 3.10 and 3.11. @rajagurunath thoughts on dropping 3.7 and 3.8? 