### PR TITLE
Replace a couple of deprecations with updated methods

### DIFF
--- a/dask_deltatable/core.py
+++ b/dask_deltatable/core.py
@@ -49,7 +49,9 @@ class DeltaTableWrapper(object):
         schema = kwargs.pop("schema", None) or self.schema
         filter = kwargs.pop("filter", None)
         if filter:
-            filter_converter = getattr(pq, "filters_to_expression", getattr(pq, "_filters_to_expression"))
+            filter_converter = getattr(
+                pq, "filters_to_expression", getattr(pq, "_filters_to_expression")
+            )
             filter_expression = filter_converter(filter)
         else:
             filter_expression = None

--- a/dask_deltatable/core.py
+++ b/dask_deltatable/core.py
@@ -49,10 +49,11 @@ class DeltaTableWrapper(object):
         schema = kwargs.pop("schema", None) or self.schema
         filter = kwargs.pop("filter", None)
         if filter:
-            filter_converter = getattr(
-                pq, "filters_to_expression", getattr(pq, "_filters_to_expression")
-            )
-            filter_expression = filter_converter(filter)
+            try:
+                filter_expression = pq.filters_to_expression(filter)
+            except AttributeError:
+                # fallback to older internal method
+                filter_expression = pq._filters_to_expression(filter)
         else:
             filter_expression = None
         return (


### PR DESCRIPTION
Minor cleanup:

* `DeltaTable.pyarrow_schema` is deprecated
* `_filters_to_expression` is deprecated
* add missing `return`.