### PR TITLE
Remove pytest ini

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,11 @@ jobs:
         run: python -m pip install -e ".[dev]"
 
       - name: Run tests
-        run: python -m pytest --junitxml=junit/test-results.xml --cov-report=xml tests
+        run: python -m pytest \
+          --junitxml=junit/test-results.xml \
+          --cov-report=xml \
+          --cov dask_deltatable \
+          tests
 
       # - name: Setup tmate session
       #   if: ${{ failure() }}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,0 @@
-[pytest]
-addopts =
-    --cov dask_deltatable
-    --cov-config=.coveragerc
-    --cov-report=term-missing
-testpaths =
-    tests


### PR DESCRIPTION
The only non-default configurations in pytest.ini were around coverage. Having coverage running every time (locally) prohibits the attachment of debuggers (they need the set trace hook to be clean). 