### PR TITLE
Do not require distributed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dask[dataframe,distribuited]
+dask[dataframe]
 deltalake
 fsspec
 pyarrow


### PR DESCRIPTION
While I strongly encourage people to use dask with distributed, it is not a requirement for this library.

There is also a typo and I have no idea what kind of problems this would cause