### PR TITLE
Do not fail CI if codecov fails to upload

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -65,5 +65,4 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov upload action fails intermittently. I notice that neither `dask` nor `distributed` specify `fail_ci_if_error: true`. I would rather not fail it here, either. It creates a false impression that something is wrong with the PR.

Example error:

```
[2023-07-13T17:55:29.890Z] ['info'] => Project root located at: /Users/runner/work/dask-deltatable/dask-deltatable
[2023-07-13T17:55:30.017Z] ['info'] -> No token specified or token is empty
[2023-07-13T17:55:30.073Z] ['info'] Searching for coverage files...
[2023-07-13T17:55:30.156Z] ['info'] Warning: Some files located via search were excluded from upload.
[2023-07-13T17:55:30.156Z] ['info'] If Codecov did not locate your files, please review https://docs.codecov.com/docs/supported-report-formats
[2023-07-13T17:55:30.157Z] ['info'] => Found 1 possible coverage files:
  coverage.xml
[2023-07-13T17:55:30.157Z] ['info'] Processing /Users/runner/work/dask-deltatable/dask-deltatable/coverage.xml...
[2023-07-13T17:55:30.160Z] ['info'] Detected GitHub Actions as the CI provider.
[2023-07-13T17:55:30.766Z] ['info'] Pinging Codecov: https://codecov.io/upload/v4?package=github-action-3.1.4-uploader-0.6.1&token=*******&branch=j-bennet%2Fdat&build=5546[25](https://github.com/dask-contrib/dask-deltatable/actions/runs/5546252909/jobs/10126268922?pr=47#step:8:26)[29](https://github.com/dask-contrib/dask-deltatable/actions/runs/5546252909/jobs/10126268922?pr=47#step:8:30)09&build_url=https%3A%2F%2Fgithub.com%2Fdask-contrib%2Fdask-deltatable%2Factions%2Fruns%2F5546252909&commit=c10f961592b9581966572d00c052cbc61290f738&job=Tests&pr=47&service=github-actions&slug=dask-contrib%2Fdask-deltatable&name=&tag=&flags=&parent=
[2023-07-13T17:55:39.872Z] ['error'] There was an error running the uploader: Error uploading to https://codecov.io: Error: There was an error fetching the storage URL during POST: 502 - 
<html><head>
<meta http-equiv="content-type" content="text/html;charset=utf-8">
<title>502 Server Error</title>
</head>
<body text=#000000 bgcolor=#ffffff>
<h1>Error: Server Error</h1>
<h2>The server encountered a temporary error and could not complete your request.<p>Please try again in [30](https://github.com/dask-contrib/dask-deltatable/actions/runs/5546252909/jobs/10126268922?pr=47#step:8:31) seconds.</h2>
<h2></h2>
</body></html>
```

cc @fjetter @jrbourbeau 

Notice how codecov thinks that the token is empty - limitation with PRs from forks:

https://github.com/codecov/codecov-action/issues/837#issuecomment-1269818885

also see discussion here:

https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954

Because token is not supplied, codecov is rate-limiting us, ergo intermittent 502.

I assume we don't want to hardcode the token like some people do:

https://github.com/codecov/codecov-action/issues/837#issuecomment-1530053511

so I'd rather not fail CI.