### PR TITLE
Fix the PickleError with RawDeltaTable

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+import zipfile
+
+import pytest
+
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(ROOT_DIR, "tests", "data")
+
+
+@pytest.fixture()
+def simple_table(tmpdir):
+    output_dir = tmpdir
+    deltaf = zipfile.ZipFile(f"{DATA_DIR}/simple.zip")
+    deltaf.extractall(output_dir)
+    return str(output_dir) + "/test1/"
+
+
+@pytest.fixture()
+def simple_table2(tmpdir):
+    output_dir = tmpdir
+    deltaf = zipfile.ZipFile(f"{DATA_DIR}/simple2.zip")
+    deltaf.extractall(output_dir)
+    return str(output_dir) + "/simple_table/"
+
+
+@pytest.fixture()
+def partition_table(tmpdir):
+    output_dir = tmpdir
+    deltaf = zipfile.ZipFile(f"{DATA_DIR}/partition.zip")
+    deltaf.extractall(output_dir)
+    return str(output_dir) + "/test2/"
+
+
+@pytest.fixture()
+def empty_table1(tmpdir):
+    output_dir = tmpdir
+    deltaf = zipfile.ZipFile(f"{DATA_DIR}/empty1.zip")
+    deltaf.extractall(output_dir)
+    return str(output_dir) + "/empty/"
+
+
+@pytest.fixture()
+def empty_table2(tmpdir):
+    output_dir = tmpdir
+    deltaf = zipfile.ZipFile(f"{DATA_DIR}/empty2.zip")
+    deltaf.extractall(output_dir)
+    return str(output_dir) + "/empty2/"
+
+
+@pytest.fixture()
+def checkpoint_table(tmpdir):
+    output_dir = tmpdir
+    deltaf = zipfile.ZipFile(f"{DATA_DIR}/checkpoint.zip")
+    deltaf.extractall(output_dir)
+    return str(output_dir) + "/checkpoint/"

--- a/dask_deltatable/core.py
+++ b/dask_deltatable/core.py
@@ -52,7 +52,7 @@ def _get_pq_files(dt: DeltaTable, filter: Filters = None) -> list[str]:
     return sorted(list(file_uris))
 
 
-def _read_delta_dataset(
+def _read_delta_partition(
     filename: str,
     schema: pa.Schema,
     fs: Any,
@@ -109,7 +109,7 @@ def _read_from_filesystem(
         meta = meta[columns]
 
     return dd.from_map(
-        partial(_read_delta_dataset, fs=fs, columns=columns, schema=schema, **kwargs),
+        partial(_read_delta_partition, fs=fs, columns=columns, schema=schema, **kwargs),
         pq_files,
         meta=meta,
         label="read-delta-table",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import glob
 import os
-import zipfile
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -12,57 +11,6 @@ import pytest
 from deltalake import DeltaTable
 
 import dask_deltatable as ddt
-
-ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
-DATA_DIR = os.path.join(ROOT_DIR, "data")
-
-
-@pytest.fixture()
-def simple_table(tmpdir):
-    output_dir = tmpdir
-    deltaf = zipfile.ZipFile(f"{DATA_DIR}/simple.zip")
-    deltaf.extractall(output_dir)
-    return str(output_dir) + "/test1/"
-
-
-@pytest.fixture()
-def simple_table2(tmpdir):
-    output_dir = tmpdir
-    deltaf = zipfile.ZipFile(f"{DATA_DIR}/simple2.zip")
-    deltaf.extractall(output_dir)
-    return str(output_dir) + "/simple_table/"
-
-
-@pytest.fixture()
-def partition_table(tmpdir):
-    output_dir = tmpdir
-    deltaf = zipfile.ZipFile(f"{DATA_DIR}/partition.zip")
-    deltaf.extractall(output_dir)
-    return str(output_dir) + "/test2/"
-
-
-@pytest.fixture()
-def empty_table1(tmpdir):
-    output_dir = tmpdir
-    deltaf = zipfile.ZipFile(f"{DATA_DIR}/empty1.zip")
-    deltaf.extractall(output_dir)
-    return str(output_dir) + "/empty/"
-
-
-@pytest.fixture()
-def empty_table2(tmpdir):
-    output_dir = tmpdir
-    deltaf = zipfile.ZipFile(f"{DATA_DIR}/empty2.zip")
-    deltaf.extractall(output_dir)
-    return str(output_dir) + "/empty2/"
-
-
-@pytest.fixture()
-def checkpoint_table(tmpdir):
-    output_dir = tmpdir
-    deltaf = zipfile.ZipFile(f"{DATA_DIR}/checkpoint.zip")
-    deltaf.extractall(output_dir)
-    return str(output_dir) + "/checkpoint/"
 
 
 def test_read_delta(simple_table):

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -79,3 +79,9 @@ def test_write_with_schema(client, tmpdir):
     ddt.to_deltalake(f"{tmpdir}", ddf, schema=schema)
     ds = pa_ds.dataset(str(tmpdir))
     assert ds.schema == schema
+
+
+def test_read(client, simple_table):
+    df = ddt.read_deltalake(simple_table)
+    assert df.columns.tolist() == ["id", "count", "temperature", "newColumn"]
+    assert df.compute().shape == (200, 4)


### PR DESCRIPTION
Fixes an error when reading a Dask dataframe with dask-deltalake and `distributed.Client`.

```
<dask.highlevelgraph.HighLevelGraph object at 0x13fac3fd0>
 0. read-delta-table-f039f9f4fa4ebf9b2dd57eb38dcfa70e
>.
Traceback (most recent call last):
  File "/Users/jbennet/mambaforge/envs/dask-deltatable/lib/python3.9/site-packages/distributed/protocol/pickle.py", line 63, in dumps
    result = pickle.dumps(x, **dump_kwargs)
TypeError: cannot pickle 'builtins.RawDeltaTable' object
```

This PR looks like a lot of changes, but that's only because I moved the data fixtures to `conftest.py` so they can be shared between modules. The real changes are all in `core.py`.

cc @fjetter 

Closes https://github.com/dask-contrib/dask-deltatable/issues/56.