### PR TITLE
Add URL to setuptools metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     name="dask-deltatable",
     version="0.3",
     description="Dask + Delta Table ",
+    url="https://github.com/dask-contrib/dask-deltatable/",
     maintainer="rajagurunath",
     maintainer_email="gurunathrajagopal@gmail.com",
     license="BSD-3-Clause",


### PR DESCRIPTION
While working on https://github.com/conda-forge/staged-recipes/pull/23636, noticed this project doesn't contain a homepage URL in the setuptools metadata - this adds that