### PR TITLE
Fix imports to work with deltalake 0.20

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,28 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 24.8.0
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.7.0
+    rev: v3.17.0
     hooks:
       - id: pyupgrade
         args:
           - --py39-plus
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.3.0
+    rev: v1.11.2
     hooks:
       - id: mypy
         # Override default --ignore-missing-imports
@@ -37,6 +37,6 @@ repos:
           - pytest
           - types-setuptools
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.1.1
     hooks:
       - id: flake8

--- a/dask_deltatable/utils.py
+++ b/dask_deltatable/utils.py
@@ -103,6 +103,7 @@ def get_partition_filters(
 
     if isinstance(filters[0][0], str):
         filters = cast(list[list[Filter]], [filters])
+    filters = cast(list[list[Filter]], filters)
 
     allowed_ops = {
         "=": "=",

--- a/dask_deltatable/write.py
+++ b/dask_deltatable/write.py
@@ -18,15 +18,17 @@ from deltalake import DeltaTable
 try:
     from deltalake.writer import MAX_SUPPORTED_PYARROW_WRITER_VERSION
 except ImportError:
-    from deltalake.writer import (  # type: ignore
-        MAX_SUPPORTED_WRITER_VERSION as MAX_SUPPORTED_PYARROW_WRITER_VERSION,
-    )
+    # Black and mypy were arguing when doing this in one line, the type: ignore kept moving around
+    from deltalake.writer import MAX_SUPPORTED_WRITER_VERSION  # type: ignore
+
+    MAX_SUPPORTED_PYARROW_WRITER_VERSION = MAX_SUPPORTED_WRITER_VERSION
+    del MAX_SUPPORTED_WRITER_VERSION
 
 try:
-    from deltalake.writer import __enforce_append_only as _enforce_append_only
-except ImportError:
     from deltalake.writer import _enforce_append_only
-    
+except ImportError:
+    from deltalake.writer import __enforce_append_only as _enforce_append_only  # type: ignore
+
 from deltalake.writer import (
     AddAction,
     DeltaJSONEncoder,

--- a/dask_deltatable/write.py
+++ b/dask_deltatable/write.py
@@ -22,13 +22,16 @@ except ImportError:
         MAX_SUPPORTED_WRITER_VERSION as MAX_SUPPORTED_PYARROW_WRITER_VERSION,
     )
 
+try:
+    from deltalake.writer import __enforce_append_only as _enforce_append_only
+except ImportError:
+    from deltalake.writer import _enforce_append_only
+    
 from deltalake.writer import (
-    PYARROW_MAJOR_VERSION,
     AddAction,
     DeltaJSONEncoder,
     DeltaProtocolError,
     DeltaStorageHandler,
-    __enforce_append_only,
     get_file_stats_from_metadata,
     get_num_idx_cols_and_stats_columns,
     get_partitions_from_path,
@@ -39,6 +42,8 @@ from toolz.itertoolz import pluck
 
 from . import utils
 from ._schema import pyarrow_to_deltalake, validate_compatible
+
+PYARROW_MAJOR_VERSION = int(pa.__version__.split(".")[0])
 
 
 def to_deltalake(
@@ -138,7 +143,7 @@ def to_deltalake(
     if table:
         table.update_incremental()
 
-    __enforce_append_only(table=table, configuration=configuration, mode=mode)
+    _enforce_append_only(table=table, configuration=configuration, mode=mode)
 
     if filesystem is None:
         if table is not None:


### PR DESCRIPTION
It looks like a couple of imports have been renamed in the last couple of `deltalake` releases. This PR updates to the new names in `deltalake==0.20` and adds backward compatibility so we can still support `deltalake==0.18`.

I also ran `pre-commit autoupdate` when fixing up some linting issues.