### PR TITLE
Add support for Databricks Unity Data Catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ df = ddt.read_deltalake("delta_path", version=3)
 df = ddt.read_deltalake("delta_path", datetime="2018-12-19T16:39:57-08:00")
 ```
 
-`df` is a Dask DataFrame that you can work with in the same way you normally would. See [the Dask DataFrame documentation](https://docs.dask.org/en/stable/dataframe.html) for available operations.
+`df` is a Dask DataFrame that you can work with in the same way you normally would. See
+[the Dask DataFrame documentation](https://docs.dask.org/en/stable/dataframe.html) for
+available operations.
 
 ### Accessing remote file systems
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ ddt.read_deltalake(catalog="glue", database_name="science", table_name="physics"
 ### Accessing Unity catalog
 
 `dask-deltatable` can connect to Unity catalog to read the delta table.
-The method will look for `DATABRICKS_HOST` and `DATABRICKS_TOKEN` environment variables
-or as `kwargs` arguments with the same name.
+The method will look for `DATABRICKS_HOST` and `DATABRICKS_TOKEN` environment
+variables or try to find them as `kwargs` with the same name but lowercase.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,22 @@ Example:
 ddt.read_deltalake(catalog="glue", database_name="science", table_name="physics")
 ```
 
+### Accessing Unity catalog
+
+`dask-deltatable` can connect to Unity catalog to read the delta table.
+The method will look for `DATABRICKS_WORKSPACE_URL` and `DATABRICKS_ACCESS_TOKEN`
+environment variables.
+
+Example:
+
+```python
+ddt.read_unity_catalog(
+    catalog_name="projects",
+    database_name="science",
+    table_name="physics"
+)
+```
+
 ### Writing to Delta Lake
 
 To write a Dask dataframe to Delta Lake, use `to_deltalake` method.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Example:
 ```python
 ddt.read_unity_catalog(
     catalog_name="projects",
-    database_name="science",
+    schema_name="science",
     table_name="physics"
 )
 ```

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ ddt.read_deltalake(catalog="glue", database_name="science", table_name="physics"
 ### Accessing Unity catalog
 
 `dask-deltatable` can connect to Unity catalog to read the delta table.
-The method will look for `DATABRICKS_WORKSPACE_URL` and `DATABRICKS_ACCESS_TOKEN`
-environment variables.
+The method will look for `DATABRICKS_HOST` and `DATABRICKS_TOKEN` environment variables
+or as `kwargs` arguments with the same name.
 
 Example:
 

--- a/dask_deltatable/__init__.py
+++ b/dask_deltatable/__init__.py
@@ -6,8 +6,6 @@ __all__ = [
     "to_deltalake",
 ]
 
-from .core import (
-    read_deltalake as read_deltalake,
-    read_unity_catalog as read_unity_catalog,
-)
+from .core import read_deltalake as read_deltalake
+from .core import read_unity_catalog as read_unity_catalog
 from .write import to_deltalake as to_deltalake

--- a/dask_deltatable/__init__.py
+++ b/dask_deltatable/__init__.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 __all__ = [
     "read_deltalake",
+    "read_unity_catalog",
     "to_deltalake",
 ]
 
-from .core import read_deltalake as read_deltalake
+from .core import (
+    read_deltalake as read_deltalake,
+    read_unity_catalog as read_unity_catalog,
+)
 from .write import to_deltalake as to_deltalake

--- a/dask_deltatable/core.py
+++ b/dask_deltatable/core.py
@@ -320,8 +320,8 @@ def read_unity_catalog(
         1. schema
         2. filter
         3. pyarrow_to_pandas
-        4. DATABRICKS_HOST
-        5. DATABRICKS_TOKEN
+        4. databricks_host
+        5. databricks_token
 
         schema: pyarrow.Schema
             Used to maintain schema evolution in deltatable.
@@ -350,10 +350,10 @@ def read_unity_catalog(
             See https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pandas
             for more.
 
-        DATABRICKS_HOST: str
+        databricks_host: str
             The Databricks workspace URL hosting the Unity Catalog.
 
-        DATABRICKS_TOKEN: str
+        databricks_token: str
             A Databricks personal access token with at least read access on the catalog.
 
     Returns
@@ -363,7 +363,8 @@ def read_unity_catalog(
 
     Notes
     -----
-    Requires the following to be set as either environment variables or in `kwargs`:
+    Requires the following to be set as either environment variables or in `kwargs` as
+    lower case:
     - DATABRICKS_HOST: The Databricks workspace URL hosting the Unity Catalog.
     - DATABRICKS_TOKEN: A Databricks personal access token with at least read access on
         the catalog.
@@ -380,13 +381,13 @@ def read_unity_catalog(
     from databricks.sdk.service.catalog import TableOperation
     try:
         workspace_client = WorkspaceClient(
-            host=os.environ.get(["DATABRICKS_HOST"], kwargs["DATABRICKS_HOST"]),
-            token=os.environ.get(["DATABRICKS_TOKEN"], kwargs["DATABRICKS_TOKEN"]),
+            host=os.environ.get(["DATABRICKS_HOST"], kwargs["databricks_host"]),
+            token=os.environ.get(["DATABRICKS_TOKEN"], kwargs["databricks_token"]),
         )
     except KeyError:
         raise ValueError(
             "Please set `DATABRICKS_HOST` and `DATABRICKS_TOKEN` either as environment"
-            " variables or as part of `kwargs`"
+            " variables or as part of `kwargs` with lowercase"
         )
     uc_full_url = f"{catalog_name}.{database_name}.{table_name}"
     table = workspace_client.tables.get(uc_full_url)

--- a/dask_deltatable/core.py
+++ b/dask_deltatable/core.py
@@ -379,10 +379,11 @@ def read_unity_catalog(
     """
     from databricks.sdk import WorkspaceClient
     from databricks.sdk.service.catalog import TableOperation
+
     try:
         workspace_client = WorkspaceClient(
-            host=os.environ.get(["DATABRICKS_HOST"], kwargs["databricks_host"]),
-            token=os.environ.get(["DATABRICKS_TOKEN"], kwargs["databricks_token"]),
+            host=os.environ.get("DATABRICKS_HOST", kwargs["databricks_host"]),
+            token=os.environ.get("DATABRICKS_TOKEN", kwargs["databricks_token"]),
         )
     except KeyError:
         raise ValueError(
@@ -407,6 +408,10 @@ def read_unity_catalog(
         file_path.replace("abfss://", "abfs://")
         for file_path in delta_table.file_uris()
     ]
-    ddf = dd.read_parquet(file_paths, **kwargs)
+    ddf = dd.read_parquet(
+        path=file_paths,
+        storage_options=storage_options,
+        **kwargs,
+    )
     return ddf
 

--- a/dask_deltatable/core.py
+++ b/dask_deltatable/core.py
@@ -295,7 +295,7 @@ def read_deltalake(
 
 def read_unity_catalog(
     catalog_name: str,
-    database_name: str,
+    schema_name: str,
     table_name: str,
     **kwargs,
 ) -> dd.DataFrame:
@@ -310,10 +310,10 @@ def read_unity_catalog(
     ----------
     catalog_name : str
         Name of the Unity Catalog catalog.
-    database_name : str
-        Name of the database within the catalog.
+    schema_name : str
+        Name of the schema within the catalog.
     table_name : str
-        Name of the table within the database.
+        Name of the table within the catalog schema.
     **kwargs
         Additional keyword arguments passed to `dask.dataframe.read_parquet`.
         Some most used parameters can be passed here are:
@@ -390,7 +390,7 @@ def read_unity_catalog(
             "Please set `DATABRICKS_HOST` and `DATABRICKS_TOKEN` either as environment"
             " variables or as part of `kwargs` with lowercase"
         )
-    uc_full_url = f"{catalog_name}.{database_name}.{table_name}"
+    uc_full_url = f"{catalog_name}.{schema_name}.{table_name}"
     table = workspace_client.tables.get(uc_full_url)
     temp_credentials = workspace_client.temporary_table_credentials.\
         generate_temporary_table_credentials(
@@ -404,12 +404,8 @@ def read_unity_catalog(
         table_uri=table.storage_location,
         storage_options=storage_options
     )
-    file_paths = [
-        file_path.replace("abfss://", "abfs://")
-        for file_path in delta_table.file_uris()
-    ]
     ddf = dd.read_parquet(
-        path=file_paths,
+        path=delta_table.file_uris(),
         storage_options=storage_options,
         **kwargs,
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 dask[dataframe]
-deltalake>=0.18
+deltalake>=1.0.2
 fsspec
 pyarrow

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     extras_require={
         "dev": ["pytest", "requests", "pytest-cov>=2.10.1"],
         "s3": ["s3fs", "boto3"],
+        "uc": ["adlfs", "databricks-sdk"],
     },
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Added a function to import delta parquet files from Unity Catalog in accordance with https://github.com/dask-contrib/dask-deltatable/issues/91. Added optional dependencies under the "uc" tag in setup.py for to be able to run this function.

Updated the deltalake requirements to 1.0.2. This might trigger problems described in this issue https://github.com/dask-contrib/dask-deltatable/issues/90. Which is why I have not increased the version of this package yet. 

The read_unity_catalog does not have a test yet. I can add one if it is required. But will have to be after the weekend then. 