### PR TITLE
Return an empty dataframe when no parquet file (fix #94)

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -111,10 +111,10 @@ def test_empty(empty_table1, empty_table2):
     df = ddt.read_deltalake(empty_table2)
     assert df.compute().shape == (0, 4)
 
-    df = ddt.read_deltalake(empty_table2, columns = ["some_struct", "value"])
+    df = ddt.read_deltalake(empty_table2, columns=["some_struct", "value"])
     assert df.compute().shape == (0, 2)
 
-    df = ddt.read_deltalake(empty_table2, columns = [])
+    df = ddt.read_deltalake(empty_table2, columns=[])
     assert df.compute().shape == (0, 0)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -108,9 +108,14 @@ def test_empty(empty_table1, empty_table2):
     df = ddt.read_deltalake(empty_table1, version=0)
     assert df.compute().shape == (5, 2)
 
-    with pytest.raises(RuntimeError):
-        # No Parquet files found
-        _ = ddt.read_deltalake(empty_table2)
+    df = ddt.read_deltalake(empty_table2)
+    assert df.compute().shape == (0, 4)
+
+    df = ddt.read_deltalake(empty_table2, columns = ["some_struct", "value"])
+    assert df.compute().shape == (0, 2)
+
+    df = ddt.read_deltalake(empty_table2, columns = [])
+    assert df.compute().shape == (0, 0)
 
 
 def test_checkpoint(checkpoint_table):


### PR DESCRIPTION
This fixes #94.

With this PR, an empty dataframe will be returned when there is no parquet file.
This is to align with the behavior of delta-rs and in theory a table should be valid even if there is no row.