### PR TITLE
Adapt to delta-rs v1.0.0 breaking changes

### DIFF
--- a/dask_deltatable/core.py
+++ b/dask_deltatable/core.py
@@ -251,7 +251,8 @@ def read_deltalake(
             )
         else:
             raise NotImplementedError(
-                "Reading from catalog is not implemented yet, please use path"
+                "Reading from a catalog used to be supported ",
+                "but currently not due to a change in the upstream delta-rs dependency.",
             )
     else:
         if path is None:

--- a/dask_deltatable/core.py
+++ b/dask_deltatable/core.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-import os
 from collections.abc import Sequence
 from typing import Any, Callable, cast
 
 import dask
 import dask.dataframe as dd
-import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 from dask.base import tokenize
@@ -153,28 +151,6 @@ def _get_type_mapper(
     )
 
 
-# def _read_from_catalog(database_name: str, table_name: str, **kwargs) -> dd.DataFrame:
-#     if ("AWS_ACCESS_KEY_ID" not in os.environ) and (
-#         "AWS_SECRET_ACCESS_KEY" not in os.environ
-#     ):
-#         # defer's installing boto3 upfront !
-#         from boto3 import Session
-
-#         session = Session()
-#         credentials = session.get_credentials()
-#         assert credentials is not None
-#         current_credentials = credentials.get_frozen_credentials()
-#         os.environ["AWS_ACCESS_KEY_ID"] = current_credentials.access_key
-#         os.environ["AWS_SECRET_ACCESS_KEY"] = current_credentials.secret_key
-#     data_catalog = DataCatalog.AWS
-#     dt = DeltaTable.from_data_catalog(
-#         data_catalog=data_catalog, database_name=database_name, table_name=table_name
-#     )
-
-#     df = dd.read_parquet(dt.file_uris(), **kwargs)
-#     return df
-
-
 def read_deltalake(
     path: str | None = None,
     catalog: str | None = None,
@@ -274,9 +250,6 @@ def read_deltalake(
                 "Since Catalog was provided, please provide Database and table name"
             )
         else:
-            # resultdf = _read_from_catalog(
-            #     database_name=database_name, table_name=table_name, **kwargs
-            # )
             raise NotImplementedError(
                 "Reading from catalog is not implemented yet, please use path"
             )

--- a/dask_deltatable/core.py
+++ b/dask_deltatable/core.py
@@ -252,7 +252,7 @@ def read_deltalake(
         else:
             raise NotImplementedError(
                 "Reading from a catalog used to be supported ",
-                "but currently not due to a change in the upstream delta-rs dependency.",
+                "but was removed from the upstream dependency delta-rs>=1.0.",
             )
     else:
         if path is None:

--- a/dask_deltatable/utils.py
+++ b/dask_deltatable/utils.py
@@ -250,7 +250,7 @@ class DeltaJSONEncoder(json.JSONEncoder):
 
 
 # Copied from delta-rs v0.25.5 (https://github.com/delta-io/delta-rs/blob/python-v0.25.5/LICENSE.txt)
-def _enforce_append_only(
+def enforce_append_only(
     table: DeltaTable | None,
     configuration: Mapping[str, str | None] | None,
     mode: str,

--- a/dask_deltatable/utils.py
+++ b/dask_deltatable/utils.py
@@ -249,6 +249,25 @@ class DeltaJSONEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
+# Copied from delta-rs v0.25.5 (https://github.com/delta-io/delta-rs/blob/python-v0.25.5/LICENSE.txt)
+def _enforce_append_only(
+    table: DeltaTable | None,
+    configuration: Mapping[str, str | None] | None,
+    mode: str,
+) -> None:
+    """Throw ValueError if table configuration contains delta.appendOnly and mode is not append"""
+    if table:
+        configuration = table.metadata().configuration
+    config_delta_append_only = (
+        configuration and configuration.get("delta.appendOnly", "false") == "true"
+    )
+    if config_delta_append_only and mode != "append":
+        raise ValueError(
+            "If configuration has delta.appendOnly = 'true', mode must be 'append'."
+            f" Mode is currently {mode}"
+        )
+
+
 # Inspired from delta-rs v0.25.5 (https://github.com/delta-io/delta-rs/blob/python-v0.25.5/LICENSE.txt)
 def get_num_idx_cols_and_stats_columns(
     table: DeltaTable | None, configuration: Mapping[str, str | None] | None

--- a/dask_deltatable/write.py
+++ b/dask_deltatable/write.py
@@ -15,18 +15,9 @@ import pyarrow.fs as pa_fs
 from dask.core import flatten
 from deltalake import CommitProperties, DeltaTable
 from deltalake import Schema as DeltaSchema
-
-try:
-    from deltalake.table import MAX_SUPPORTED_PYARROW_WRITER_VERSION
-except ImportError:
-    # Black and mypy were arguing when doing this in one line, the type: ignore kept moving around
-    from deltalake.table import MAX_SUPPORTED_WRITER_VERSION  # type: ignore
-
-    MAX_SUPPORTED_PYARROW_WRITER_VERSION = MAX_SUPPORTED_WRITER_VERSION
-    del MAX_SUPPORTED_WRITER_VERSION
-
 from deltalake.exceptions import DeltaProtocolError
 from deltalake.fs import DeltaStorageHandler
+from deltalake.table import MAX_SUPPORTED_PYARROW_WRITER_VERSION
 from deltalake.transaction import AddAction, create_table_with_add_actions
 from deltalake.writer.writer import try_get_table_and_table_uri
 from toolz.itertoolz import pluck

--- a/dask_deltatable/write.py
+++ b/dask_deltatable/write.py
@@ -134,7 +134,7 @@ def to_deltalake(
     if table:
         table.update_incremental()
 
-    # _enforce_append_only(table=table, configuration=configuration, mode=mode)
+    utils._enforce_append_only(table=table, configuration=configuration, mode=mode)
 
     if filesystem is None:
         if table is not None:

--- a/dask_deltatable/write.py
+++ b/dask_deltatable/write.py
@@ -125,7 +125,7 @@ def to_deltalake(
     if table:
         table.update_incremental()
 
-    utils._enforce_append_only(table=table, configuration=configuration, mode=mode)
+    utils.enforce_append_only(table=table, configuration=configuration, mode=mode)
 
     if filesystem is None:
         if table is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 dask[dataframe]
-deltalake>=0.18
+deltalake>=1.0.0
 fsspec
 pyarrow

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -184,6 +184,9 @@ def test_catalog_with_error():
     )
 
 
+@pytest.mark.skip(
+    reason="DeltaTable.from_data_catalog was removed in v0.15.0. Skip until _read_from_catalog is adapted to this change."
+)
 def test_catalog(simple_table):
     dt = MagicMock()
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -185,7 +185,7 @@ def test_catalog_with_error():
 
 
 @pytest.mark.skip(
-    reason="DeltaTable.from_data_catalog was removed in v0.15.0. Skip until _read_from_catalog is adapted to this change."
+    reason="DeltaTable.from_data_catalog was removed in delta-rs v0.15.0. Skip until _read_from_catalog is adapted to this change."
 )
 def test_catalog(simple_table):
     dt = MagicMock()


### PR DESCRIPTION
This PR adapts dask-deltatable to the delta-rs v1.0.0 breaking changes.
Most notably, this PR has to comment out the ability to read from catalog as the underlying interface was removed from delta-rs.