### PR TITLE
Unblock CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0  # Needed by codecov.io
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v3.2.0
         with:
           miniforge-version: latest
           channel-priority: strict

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,7 +58,7 @@ jobs:
         if: >
           always() &&
           (steps.run_tests.outcome == 'success' || steps.run_tests.outcome == 'failure')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: reports
 


### PR DESCRIPTION
CI is currently blocked

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

E.g https://github.com/dask-contrib/dask-deltatable/actions/runs/15908120261/job/44914984949?pr=96