### PR TITLE
Fix schema mismatch

### DIFF
--- a/dask_deltatable/core.py
+++ b/dask_deltatable/core.py
@@ -105,7 +105,7 @@ def _read_from_filesystem(
     if datetime is not None:
         dt.load_as_version(datetime)
 
-    schema = pa.schema(dt.schema().to_arrow())
+    schema = pa.schema(dt.schema())
 
     filter_value = cast(Filters, kwargs.get("filter", None))
     pq_files = _get_pq_files(dt, filter=filter_value)

--- a/dask_deltatable/write.py
+++ b/dask_deltatable/write.py
@@ -144,7 +144,7 @@ def to_deltalake(
     if table:  # already exists
         if (
             schema is not None
-            and schema != table.schema().to_arrow()
+            and DeltaSchema.from_arrow(schema) != table.schema()
             and not (mode == "overwrite" and overwrite_schema)
         ):
             raise ValueError(

--- a/dask_deltatable/write.py
+++ b/dask_deltatable/write.py
@@ -144,7 +144,7 @@ def to_deltalake(
     if table:  # already exists
         if (
             schema is not None
-            and DeltaSchema.from_arrow(schema) != table.schema()
+            and schema != pa.schema(table.schema())
             and not (mode == "overwrite" and overwrite_schema)
         ):
             raise ValueError(

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -5,6 +5,7 @@ import unittest.mock as mock
 
 import dask.dataframe as dd
 import pandas as pd
+import pyarrow as pa
 import pytest
 from dask.dataframe.utils import assert_eq
 from dask.datasets import timeseries
@@ -97,3 +98,13 @@ def test_custom_metadata(tmpdir):
     dt = DeltaTable(tmpdir)
     assert "foo" in dt.history()[-1]
     assert dt.history()[-1]["foo"] == "bar"
+
+
+def test_append_with_schema(tmpdir):
+    """Ensure we can append to a table with a schema"""
+    tmpdir = str(tmpdir)
+    df = pd.DataFrame({"a": [1, 2, 3, 4]})
+    ddf = dd.from_pandas(df, npartitions=2)
+    schema = pa.Schema.from_pandas(df)
+    to_deltalake(tmpdir, ddf, schema=schema)
+    to_deltalake(tmpdir, ddf, schema=schema, mode="append")


### PR DESCRIPTION
As demostrated in test_append_with_schema below,
```python
def test_append_with_schema(tmpdir):
    """Ensure we can append to a table with a schema"""
    tmpdir = str(tmpdir)
    df = pd.DataFrame({"a": [1, 2, 3, 4]})
    ddf = dd.from_pandas(df, npartitions=2)
    schema = pa.Schema.from_pandas(df)
    to_deltalake(tmpdir, ddf, schema=schema)
    to_deltalake(tmpdir, ddf, schema=schema, mode="append")
```
this fails as of 032253f45a60566d3b3bcb4408f669cdc9ce6651 in main branch due to "Schema of data does not match table schema" because we currently compare pyarrow.Schema (as in `schema`) and arro3.core.Schema (as in `table.schema().to_arrow()`).
https://github.com/dask-contrib/dask-deltatable/blob/032253f45a60566d3b3bcb4408f669cdc9ce6651/dask_deltatable/write.py#L144-L153
We should align the schema class before comparison.